### PR TITLE
Feat Footer

### DIFF
--- a/app/components/Footer/Footer.module.css
+++ b/app/components/Footer/Footer.module.css
@@ -1,0 +1,23 @@
+.footer {
+  margin-top: 40px;
+  border-top: 1px solid
+    light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+}
+
+.inner {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: var(--mantine-spacing-xl);
+  padding-bottom: var(--mantine-spacing-xl);
+
+  @media (max-width: $mantine-breakpoint-xs) {
+    flex-direction: column;
+  }
+}
+
+.links {
+  @media (max-width: $mantine-breakpoint-xs) {
+    margin-top: var(--mantine-spacing-md);
+  }
+}

--- a/app/components/Footer/Footer.tsx
+++ b/app/components/Footer/Footer.tsx
@@ -1,0 +1,34 @@
+import {
+  IconBrandInstagram,
+  IconBrandTwitter,
+  IconBrandYoutube,
+} from "@tabler/icons-react";
+import { ActionIcon, Container, Group } from "@mantine/core";
+import classes from "./Footer.module.css";
+import { FintrackLogo } from "../Logo/FintrackLogo";
+
+export function Footer() {
+  return (
+    <div className={classes.footer}>
+      <Container className={classes.inner}>
+        <FintrackLogo />
+        <Group
+          gap={0}
+          className={classes.links}
+          justify="flex-end"
+          wrap="nowrap"
+        >
+          <ActionIcon size="lg" color="gray" variant="subtle">
+            <IconBrandTwitter size={18} stroke={1.5} />
+          </ActionIcon>
+          <ActionIcon size="lg" color="gray" variant="subtle">
+            <IconBrandYoutube size={18} stroke={1.5} />
+          </ActionIcon>
+          <ActionIcon size="lg" color="gray" variant="subtle">
+            <IconBrandInstagram size={18} stroke={1.5} />
+          </ActionIcon>
+        </Group>
+      </Container>
+    </div>
+  );
+}

--- a/app/components/Header/Header.module.css
+++ b/app/components/Header/Header.module.css
@@ -1,6 +1,6 @@
 .header {
   height: 56px;
-  margin-bottom: 120px;
+  margin-bottom: 40px;
   background-color: var(--mantine-color-body);
   border-bottom: 1px solid
     light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
@@ -63,16 +63,4 @@
 .menuItem {
   color: inherit;
   text-decoration: none;
-}
-
-.title {
-  color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
-  font-size: rem(35px);
-  font-weight: 900;
-  letter-spacing: rem(0px);
-  text-decoration: none;
-
-  @media (max-width: $mantine-breakpoint-md) {
-    font-size: rem(50px);
-  }
 }

--- a/app/components/Header/Header.tsx
+++ b/app/components/Header/Header.tsx
@@ -1,19 +1,10 @@
-import {
-  Burger,
-  Container,
-  Drawer,
-  Group,
-  Stack,
-  Text,
-  Title,
-} from "@mantine/core";
+import { Burger, Container, Drawer, Group, Stack } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 import classes from "./Header.module.css";
 import { Link, useLoaderData } from "@remix-run/react";
 import { UserMenu } from "./UserMenu/UserMenu";
 import { loader } from "~/root";
-
-const homeLink = { link: "/", label: "Home" };
+import { FintrackLogo } from "../Logo/FintrackLogo";
 
 const links = [
   { link: "/dashboard", label: "Dashboard" },
@@ -46,22 +37,7 @@ export function Header() {
   return (
     <header className={classes.header}>
       <Container size="md" className={classes.inner}>
-        <Link
-          key={homeLink.label}
-          to={homeLink.link}
-          className={classes.menuItem}
-        >
-          <Title className={classes.title} ta="center">
-            <Text
-              inherit
-              variant="gradient"
-              component="span"
-              gradient={{ from: "pink", to: "yellow" }}
-            >
-              FinTrack
-            </Text>
-          </Title>
-        </Link>
+        <FintrackLogo />
         <Group gap={5} visibleFrom="xs">
           {user ? (
             <>

--- a/app/components/Logo/FinTrackLogo.module.css
+++ b/app/components/Logo/FinTrackLogo.module.css
@@ -1,0 +1,16 @@
+.title {
+  color: light-dark(var(--mantine-color-black), var(--mantine-color-white));
+  font-size: rem(35px);
+  font-weight: 900;
+  letter-spacing: rem(0px);
+  text-decoration: none;
+
+  @media (max-width: $mantine-breakpoint-md) {
+    font-size: rem(50px);
+  }
+}
+
+.menuItem {
+  color: inherit;
+  text-decoration: none;
+}

--- a/app/components/Logo/FintrackLogo.tsx
+++ b/app/components/Logo/FintrackLogo.tsx
@@ -1,0 +1,22 @@
+import { Text, Title } from "@mantine/core";
+import { Link } from "@remix-run/react";
+import classes from "./FinTrackLogo.module.css";
+
+const homeLink = { link: "/", label: "Home" };
+
+export function FintrackLogo() {
+  return (
+    <Link key={homeLink.label} to={homeLink.link} className={classes.menuItem}>
+      <Title className={classes.title} ta="center">
+        <Text
+          inherit
+          variant="gradient"
+          component="span"
+          gradient={{ from: "pink", to: "yellow" }}
+        >
+          FinTrack
+        </Text>
+      </Title>
+    </Link>
+  );
+}

--- a/app/components/Main/Body.module.css
+++ b/app/components/Main/Body.module.css
@@ -1,0 +1,12 @@
+html,
+body,
+.app-container {
+  height: 100%;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.body {
+  flex: 1;
+}

--- a/app/components/Main/Body.tsx
+++ b/app/components/Main/Body.tsx
@@ -1,0 +1,6 @@
+import { ReactNode } from "react";
+import classes from "./Body.module.css";
+
+export function Body({ children }: { children: ReactNode }) {
+  return <div className={classes.body}>{children}</div>;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -12,6 +12,8 @@ import { Header } from "./components/Header/Header";
 import { ActionFunctionArgs } from "@remix-run/node";
 import { getUser } from "./services/authentication/middleware";
 import "@mantine/dates/styles.css";
+import { Footer } from "./components/Footer/Footer";
+import { Body } from "./components/Main/Body";
 
 export const loader = async ({ request }: ActionFunctionArgs) => {
   const user = await getUser({ request } as ActionFunctionArgs);
@@ -31,7 +33,10 @@ export default function App() {
       <body>
         <MantineProvider defaultColorScheme="dark">
           <Header />
-          <Outlet />
+          <Body>
+            <Outlet />
+          </Body>
+          <Footer />
         </MantineProvider>
         <ScrollRestoration />
         <Scripts />


### PR DESCRIPTION
This pull request includes several changes to the layout and structure of the `Footer`, `Header`, and `Body` components, as well as the addition of a new `FintrackLogo` component. The changes focus on improving the styling and organization of these components.

### Footer Enhancements:
* Added new CSS styles for the `Footer` component to enhance its layout and responsiveness (`app/components/Footer/Footer.module.css`).
* Updated the `Footer` component to include social media icons and use the new styles (`app/components/Footer/Footer.tsx`).

### Header Modifications:
* Adjusted the margin and removed the title styles from the `Header` component to streamline its appearance (`app/components/Header/Header.module.css`). [[1]](diffhunk://#diff-a93872dd350656fb19e33d0588c51eec293ed504971a026821994b2cb3f8fa3aL3-R3) [[2]](diffhunk://#diff-a93872dd350656fb19e33d0588c51eec293ed504971a026821994b2cb3f8fa3aL67-L78)
* Updated the `Header` component to use the new `FintrackLogo` component (`app/components/Header/Header.tsx`). [[1]](diffhunk://#diff-2873e60962c16b9b30ef5a88f9095f1bad846a5284d9089647f2493dd794cea1L1-R7) [[2]](diffhunk://#diff-2873e60962c16b9b30ef5a88f9095f1bad846a5284d9089647f2493dd794cea1L49-R40)

### New FintrackLogo Component:
* Created a new `FintrackLogo` component for consistent branding across the application (`app/components/Logo/FintrackLogo.tsx`).
* Added corresponding CSS styles for the `FintrackLogo` component (`app/components/Logo/FinTrackLogo.module.css`).

### Body Component:
* Added a new `Body` component to wrap the main content and ensure proper layout (`app/components/Main/Body.tsx`).
* Included CSS styles for the `Body` component to manage the height and layout (`app/components/Main/Body.module.css`).

### Root Component Updates:
* Updated the `root` component to include the new `Footer` and `Body` components, ensuring a consistent layout across the application (`app/root.tsx`). [[1]](diffhunk://#diff-4133eb55408b25b35b8e07c696a9dfc97b741c555d7407e8c86d0845e5eecc28R15-R16) [[2]](diffhunk://#diff-4133eb55408b25b35b8e07c696a9dfc97b741c555d7407e8c86d0845e5eecc28R36-R39)