### PR TITLE
feat: update footer to include GitHub and LinkedIn icons with links

### DIFF
--- a/app/components/Footer/Footer.tsx
+++ b/app/components/Footer/Footer.tsx
@@ -1,8 +1,4 @@
-import {
-  IconBrandInstagram,
-  IconBrandTwitter,
-  IconBrandYoutube,
-} from "@tabler/icons-react";
+import { IconBrandGithub, IconBrandLinkedin } from "@tabler/icons-react";
 import { ActionIcon, Container, Group } from "@mantine/core";
 import classes from "./Footer.module.css";
 import { FintrackLogo } from "../Logo/FintrackLogo";
@@ -18,14 +14,23 @@ export function Footer() {
           justify="flex-end"
           wrap="nowrap"
         >
-          <ActionIcon size="lg" color="gray" variant="subtle">
-            <IconBrandTwitter size={18} stroke={1.5} />
+          <ActionIcon
+            component="a"
+            href="https://github.com/Nicolass2001"
+            size="lg"
+            color="gray"
+            variant="subtle"
+          >
+            <IconBrandGithub size={18} stroke={1.5} />
           </ActionIcon>
-          <ActionIcon size="lg" color="gray" variant="subtle">
-            <IconBrandYoutube size={18} stroke={1.5} />
-          </ActionIcon>
-          <ActionIcon size="lg" color="gray" variant="subtle">
-            <IconBrandInstagram size={18} stroke={1.5} />
+          <ActionIcon
+            component="a"
+            href="https://www.linkedin.com/in/nicolas-pereira-9b4b83259/"
+            size="lg"
+            color="gray"
+            variant="subtle"
+          >
+            <IconBrandLinkedin size={18} stroke={1.5} />
           </ActionIcon>
         </Group>
       </Container>


### PR DESCRIPTION
This pull request includes updates to the social media icons and links in the `Footer` component. The changes replace the existing social media icons with new ones and add corresponding links.

Updates to social media icons and links:

* [`app/components/Footer/Footer.tsx`](diffhunk://#diff-350b7876bea77ca8c167477327c4e1467133281446741798941668ddb2a8ea29L1-R1): Replaced `IconBrandInstagram`, `IconBrandTwitter`, and `IconBrandYoutube` imports with `IconBrandGithub` and `IconBrandLinkedin`.
* [`app/components/Footer/Footer.tsx`](diffhunk://#diff-350b7876bea77ca8c167477327c4e1467133281446741798941668ddb2a8ea29L21-R33): Updated the `Footer` function to remove `IconBrandTwitter`, `IconBrandYoutube`, and `IconBrandInstagram` icons, and added `IconBrandGithub` and `IconBrandLinkedin` icons with appropriate links.