### PR TITLE
1.2.3 Hot-Fix: Transaction decimal amount bug

### DIFF
--- a/app/services/transaction/transaction.ts
+++ b/app/services/transaction/transaction.ts
@@ -87,7 +87,7 @@ export function validateTransactionData(
     throw new Error("Invalid transaction data");
   }
   return {
-    amount: parseFloat((amount as string).replace(",", ".").replace(".", "")),
+    amount: parseFloat((amount as string).replace(".", "").replace(",", ".")),
     description: description as string,
     date: new Date(date as string),
     accountId: accountId as string,


### PR DESCRIPTION
This pull request includes a small but crucial change to the `validateTransactionData` function in the `transaction.ts` file. The change corrects the parsing of the `amount` field to handle different decimal and thousand separators appropriately.

* [`app/services/transaction/transaction.ts`](diffhunk://#diff-45b2dcdba3ba8db173df162dfd222c207c8aee60664b489a6adfdcadf7385886L90-R90): Modified the `amount` parsing logic to correctly replace the thousand separator (comma) and decimal separator (dot).